### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
         "psr-0": {"Zend_": "library/"}
     },
     "replace": {
-        "zendframework/zendframework1": "1.12.*",
-        "zend/zendframework": "1.*"
+        "zendframework/zendframework1": "1.12.7",
     },
     "conflict": {
         "zendframework/zendframework1": "<1.12"
-    }
+    },
+    "abandoned": "zendframework/zendframework1"
 }


### PR DESCRIPTION
Claiming this replaces 1.12.\* from upstream Zend will claim this contains all security fixes from 1.12.7 up to 1.12.18. It doesn't. Is it still maintained?
